### PR TITLE
Add scripts to reproduce EACL23 disagreement experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/eacl23_disagreement/README.md
+++ b/eacl23_disagreement/README.md
@@ -1,0 +1,44 @@
+# Reproducing EACL'23 "Why Don’t You Do It Right?" experiments
+
+## Requirements
+- Python 3.8+
+- [MaChAmp](https://github.com/machamp-nlp/machamp): clone the repo and run `pip install -r machamp/requirements.txt`
+- `scikit-learn` for scoring (`pip install scikit-learn`)
+
+## Data
+Request/download MD-Agreement and MD-Agreement-v2 (taxonomy) from the authors’ repository (see their README and request form). The EACL paper points to the same link.
+
+## Steps
+1. **Normalize data**
+   ```bash
+   python3 prepare_data.py \
+     --train_csv /path/to/MD-Agreement/train.csv \
+     --dev_csv   /path/to/MD-Agreement/dev.csv \
+     --test_csv  /path/to/MD-Agreement/test.csv \
+     --taxonomy_path /path/to/MD-Agreement-v2/Category_dataset.tsv \
+     --id_col tweet_id --text_col text \
+     --gold_col gold_label_or_empty --agr_col agreement_or_empty \
+     --ann_cols ann1 ann2 ann3 ann4 ann5 \
+     --prefer_taxonomy_agr \
+     --outdir data/md_agreement
+   ```
+
+2. **Make training variants (Sec. 5.2)**
+
+   ```bash
+   python3 make_splits.py --base_dir data/md_agreement --out_root data/splits
+   ```
+
+3. **Run everything (20 restarts each)**
+
+   ```bash
+   bash run_experiments.sh
+   ```
+
+4. **Outputs**
+   - Predictions: `results/*.pred.txt`
+   - Table 2 JSONs: `results/table2_by_subtype.json`, `results/table2_by_category.json`
+   - Table 3 JSONs: `results/table3_App.json`, `results/table3_App_A0all.json`, `results/table3_App_A0_SUBJ.json`, `results/table3_App_A0_MISS.json`, `results/table3_App_A0_AMB.json`
+   - Table 4 JSONs: `results/table4_MTL3.json`, `results/table4_MTL6.json`
+
+The JSONs include mean and standard deviation across 20 runs for `ALL`, `OFF`, and `NOT`. They should align with the reported micro-F1 and deviations in Tables 2–4.

--- a/eacl23_disagreement/gen_config.py
+++ b/eacl23_disagreement/gen_config.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Generate MaChAmp dataset configs."""
+
+import argparse
+import json
+import os
+
+TEMPLATE = {
+    "MD": {
+        "train_data_path": "",
+        "dev_data_path": "",
+        "test_data_path": "",
+        "sent_idxs": [0],
+        "tasks": {
+            "offense": {"task_type": "classification", "column_idx": 1}
+        },
+    }
+}
+
+
+def add_aux_agr3(config):
+    config["MD"]["tasks"]["agr3"] = {
+        "task_type": "classification",
+        "column_idx": 2,
+    }
+    return config
+
+
+def add_aux_agr6(config):
+    config["MD"]["tasks"]["agr6"] = {
+        "task_type": "classification",
+        "column_idx": 3,
+    }
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate MaChAmp config JSONs.")
+    parser.add_argument("--split_dir", required=True, help="Directory with train/dev/test TSVs")
+    parser.add_argument("--out", required=True, help="Output JSON path")
+    parser.add_argument(
+        "--mode",
+        choices=["single", "mtl3", "mtl6"],
+        default="single",
+        help="single-task or multi-task variants",
+    )
+    args = parser.parse_args()
+
+    config = json.loads(json.dumps(TEMPLATE))
+    config["MD"]["train_data_path"] = os.path.join(args.split_dir, "train.tsv")
+    config["MD"]["dev_data_path"] = os.path.join(args.split_dir, "dev.tsv")
+    config["MD"]["test_data_path"] = os.path.join(args.split_dir, "test.tsv")
+
+    if args.mode == "mtl3":
+        config = add_aux_agr3(config)
+    if args.mode == "mtl6":
+        config = add_aux_agr6(config)
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w", encoding="utf8") as handle:
+        json.dump(config, handle, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/eacl23_disagreement/make_splits.py
+++ b/eacl23_disagreement/make_splits.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Create training variants for disagreement experiments."""
+
+import argparse
+import os
+import shutil
+
+
+def read_tsv(path):
+    with open(path, encoding="utf8") as handle:
+        for line in handle:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 6:
+                continue
+            yield parts
+
+
+def write_tsv(path, rows):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf8") as handle:
+        for row in rows:
+            handle.write("\t".join(row) + "\n")
+
+
+def _norm(value):
+    return (value or "").strip().lower().replace(" ", "_")
+
+
+def cat_is(row, key):
+    category = _norm(row[4] if len(row) > 4 else "")
+    return category == _norm(key)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create MaChAmp split directories")
+    parser.add_argument("--base_dir", default="data/md_agreement")
+    parser.add_argument("--out_root", default="data/splits")
+    args = parser.parse_args()
+
+    train_rows = list(read_tsv(os.path.join(args.base_dir, "train.tsv")))
+
+    is_App = lambda row: row[2] in {"A++", "A+"}
+    is_A0 = lambda row: row[2] == "A0"
+
+    variants = {
+        "App": [row for row in train_rows if is_App(row)],
+        "App_A0all": train_rows[:],
+        "App_A0_SUBJ": [
+            row
+            for row in train_rows
+            if is_App(row) or (is_A0(row) and cat_is(row, "Subjectivity"))
+        ],
+        "App_A0_MISS": [
+            row
+            for row in train_rows
+            if is_App(row) or (is_A0(row) and cat_is(row, "Missing_Info"))
+        ],
+        "App_A0_AMB": [
+            row
+            for row in train_rows
+            if is_App(row) or (is_A0(row) and cat_is(row, "Ambiguity"))
+        ],
+    }
+
+    for name, rows in variants.items():
+        out_dir = os.path.join(args.out_root, name)
+        write_tsv(os.path.join(out_dir, "train.tsv"), rows)
+        os.makedirs(out_dir, exist_ok=True)
+        shutil.copy2(os.path.join(args.base_dir, "dev.tsv"), os.path.join(out_dir, "dev.tsv"))
+        shutil.copy2(os.path.join(args.base_dir, "test.tsv"), os.path.join(out_dir, "test.tsv"))
+        print(name, "train_size:", len(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/eacl23_disagreement/params-bert-base-uncased.json
+++ b/eacl23_disagreement/params-bert-base-uncased.json
@@ -1,0 +1,3 @@
+{
+  "transformer_model": "bert-base-uncased"
+}

--- a/eacl23_disagreement/prepare_data.py
+++ b/eacl23_disagreement/prepare_data.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Normalize MD-Agreement data for MaChAmp."""
+
+import argparse
+import csv
+import os
+import re
+from collections import Counter
+
+
+def _sniff_sep(path):
+    """Heuristically choose delimiter for CSV/TSV files."""
+    with open(path, "r", encoding="utf8", newline="") as f:
+        head = f.read(4096)
+    if "\t" in head and head.count("\t") >= head.count(","):
+        return "\t"
+    return ","
+
+
+def _norm_off(label):
+    """Normalize offensive labels to OFF/NOT."""
+    label = str(label).strip().lower()
+    if label in {"off", "offensive", "1", "true", "toxic"}:
+        return "OFF"
+    if label in {"not", "non-offensive", "0", "false", "clean", "none"}:
+        return "NOT"
+    raise ValueError(f"Unrecognized label: {label}")
+
+
+def _majority_and_agreement(row, annotator_cols):
+    """Derive majority offensive label and agreement tier."""
+    labels = [
+        _norm_off(row[col])
+        for col in annotator_cols
+        if col in row and str(row[col]).strip() != ""
+    ]
+    if len(labels) != 5:
+        raise ValueError("Expected 5 annotator labels to derive majority/agreement.")
+
+    counts = Counter(labels)
+    majority_label, majority_votes = counts.most_common(1)[0]
+    if majority_votes == 5:
+        agreement = "A++"
+    elif majority_votes == 4:
+        agreement = "A+"
+    elif majority_votes == 3:
+        agreement = "A0"
+    else:
+        raise ValueError(f"Unexpected vote distribution: {counts}")
+    return majority_label, agreement
+
+
+def _read_dict(path, sep=None):
+    """Yield rows from CSV/TSV as dictionaries."""
+    delimiter = sep or _sniff_sep(path)
+    with open(path, encoding="utf8", newline="") as handle:
+        yield from csv.DictReader(handle, delimiter=delimiter)
+
+
+ID_DIGITS = re.compile(r"^(\d+)")
+
+
+def _id_base(identifier):
+    if identifier is None:
+        return ""
+    identifier = str(identifier).strip()
+    match = ID_DIGITS.match(identifier)
+    return match.group(1) if match else identifier
+
+
+def load_taxonomy(tax_path):
+    """Load taxonomy annotations from Category_dataset.tsv."""
+    if not tax_path or not os.path.exists(tax_path):
+        return {}
+
+    delimiter = _sniff_sep(tax_path)
+    taxonomy = {}
+    for row in _read_dict(tax_path, sep=delimiter):
+        tweet_id = _id_base(row.get("ID"))
+        taxonomy[tweet_id] = {
+            "text": (row.get("Text") or "").strip(),
+            "agr": (row.get("Agreement_level") or "").strip(),
+            "primary_cat": (row.get("Primary_category") or "").strip(),
+            "primary_subcat": (row.get("Primary_subcategry") or "").strip(),
+            "secondary_cat": (row.get("Secondary_category") or "").strip(),
+            "secondary_subcat": (row.get("Seconday_subcategory") or "").strip(),
+        }
+    return taxonomy
+
+
+def process_split(
+    in_path,
+    out_path,
+    taxonomy,
+    id_col,
+    text_col,
+    gold_col=None,
+    agr_col=None,
+    ann_cols=None,
+    prefer_taxonomy_agr=True,
+):
+    """Convert a raw MD-Agreement split into MaChAmp TSV format."""
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    delimiter = _sniff_sep(in_path)
+
+    with open(in_path, encoding="utf8", newline="") as in_handle, open(
+        out_path, "w", encoding="utf8"
+    ) as out_handle:
+        reader = csv.DictReader(in_handle, delimiter=delimiter)
+        for row in reader:
+            tweet_id = _id_base(row.get(id_col))
+            text = (row.get(text_col) or "").replace("\n", " ").strip()
+
+            if gold_col and row.get(gold_col, "") != "":
+                offensive = _norm_off(row[gold_col])
+            elif ann_cols:
+                offensive, _ = _majority_and_agreement(row, ann_cols)
+            else:
+                raise ValueError("Need --gold_col or --ann_cols to derive OFF/NOT.")
+
+            if prefer_taxonomy_agr and tweet_id in taxonomy and taxonomy[tweet_id]["agr"]:
+                agreement = taxonomy[tweet_id]["agr"]
+            elif agr_col and row.get(agr_col, "") != "":
+                agreement = row[agr_col].strip()
+            elif ann_cols:
+                _, agreement = _majority_and_agreement(row, ann_cols)
+            else:
+                agreement = ""
+
+            agr6 = f"{agreement}_{offensive}" if agreement else ""
+
+            info = taxonomy.get(tweet_id, {})
+            main_cat = info.get("primary_cat", "")
+            subtype = info.get("primary_subcat", "")
+            secondary_cat = info.get("secondary_cat", "")
+            secondary_subtype = info.get("secondary_subcat", "")
+
+            columns = [
+                text,
+                offensive,
+                agreement,
+                agr6,
+                main_cat,
+                subtype,
+                secondary_cat,
+                secondary_subtype,
+            ]
+            out_handle.write("\t".join(columns) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Normalize MD-Agreement splits for MaChAmp training."
+    )
+    parser.add_argument("--train_csv", required=True, help="MD-Agreement train split")
+    parser.add_argument("--dev_csv", required=True, help="MD-Agreement dev split")
+    parser.add_argument("--test_csv", required=True, help="MD-Agreement test split")
+    parser.add_argument(
+        "--taxonomy_path",
+        required=True,
+        help="Path to Category_dataset.tsv (taxonomy annotations)",
+    )
+    parser.add_argument("--id_col", default="tweet_id")
+    parser.add_argument("--text_col", default="text")
+    parser.add_argument(
+        "--gold_col",
+        default=None,
+        help="Column containing gold OFF/NOT labels (optional if deriving from annotators)",
+    )
+    parser.add_argument(
+        "--agr_col",
+        default=None,
+        help="Column containing agreement labels (A++/A+/A0), optional",
+    )
+    parser.add_argument(
+        "--ann_cols",
+        nargs="*",
+        default=None,
+        help="Names of five annotator columns to derive labels if needed",
+    )
+    parser.add_argument(
+        "--prefer_taxonomy_agr",
+        action="store_true",
+        help="Use taxonomy agreement labels when available",
+    )
+    parser.add_argument("--outdir", default="data/md_agreement")
+    args = parser.parse_args()
+
+    taxonomy = load_taxonomy(args.taxonomy_path)
+    os.makedirs(args.outdir, exist_ok=True)
+
+    process_split(
+        args.train_csv,
+        os.path.join(args.outdir, "train.tsv"),
+        taxonomy,
+        args.id_col,
+        args.text_col,
+        args.gold_col,
+        args.agr_col,
+        args.ann_cols,
+        args.prefer_taxonomy_agr,
+    )
+    process_split(
+        args.dev_csv,
+        os.path.join(args.outdir, "dev.tsv"),
+        taxonomy,
+        args.id_col,
+        args.text_col,
+        args.gold_col,
+        args.agr_col,
+        args.ann_cols,
+        args.prefer_taxonomy_agr,
+    )
+    process_split(
+        args.test_csv,
+        os.path.join(args.outdir, "test.tsv"),
+        taxonomy,
+        args.id_col,
+        args.text_col,
+        args.gold_col,
+        args.agr_col,
+        args.ann_cols,
+        args.prefer_taxonomy_agr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/eacl23_disagreement/run_experiments.sh
+++ b/eacl23_disagreement/run_experiments.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MACHAMP_DIR=${MACHAMP_DIR:-"$ROOT/../machamp"}
+PARAMS="$ROOT/params-bert-base-uncased.json"
+BASE="$ROOT/data/md_agreement"
+SPLITS="$ROOT/data/splits"
+OUT="$ROOT/results"
+CONFIG_DIR="$ROOT/configs"
+
+mkdir -p "$OUT" "$CONFIG_DIR"
+
+# 0) Generate configs per split/mode
+python3 "$ROOT/gen_config.py" --split_dir "$SPLITS/App"         --mode single --out "$CONFIG_DIR/app.single.json"
+python3 "$ROOT/gen_config.py" --split_dir "$SPLITS/App_A0all"   --mode single --out "$CONFIG_DIR/app_a0all.single.json"
+python3 "$ROOT/gen_config.py" --split_dir "$SPLITS/App_A0_SUBJ" --mode single --out "$CONFIG_DIR/app_a0subj.single.json"
+python3 "$ROOT/gen_config.py" --split_dir "$SPLITS/App_A0_MISS" --mode single --out "$CONFIG_DIR/app_a0miss.single.json"
+python3 "$ROOT/gen_config.py" --split_dir "$SPLITS/App_A0_AMB"  --mode single --out "$CONFIG_DIR/app_a0amb.single.json"
+python3 "$ROOT/gen_config.py" --split_dir "$SPLITS/App_A0all"   --mode mtl3   --out "$CONFIG_DIR/app_a0all.mtl3.json"
+python3 "$ROOT/gen_config.py" --split_dir "$SPLITS/App_A0all"   --mode mtl6   --out "$CONFIG_DIR/app_a0all.mtl6.json"
+
+cd "$MACHAMP_DIR"
+shopt -s globstar
+SEEDS=${SEEDS:-"$(seq 1 20)"}
+
+run_train() {
+  local config_path="$1"
+  local run_prefix="$2"
+  for seed in $SEEDS; do
+    echo "[TRAIN] ${run_prefix} seed=${seed}"
+    python3 train.py \
+      --dataset_configs "$config_path" \
+      --parameters_config "$PARAMS" \
+      --device 0 \
+      --name "${run_prefix}_s${seed}"
+  done
+}
+
+run_train "$CONFIG_DIR/app.single.json"        "EACL23_App"
+run_train "$CONFIG_DIR/app_a0all.single.json"  "EACL23_AppA0all"
+run_train "$CONFIG_DIR/app_a0subj.single.json" "EACL23_AppA0subj"
+run_train "$CONFIG_DIR/app_a0miss.single.json" "EACL23_AppA0miss"
+run_train "$CONFIG_DIR/app_a0amb.single.json"  "EACL23_AppA0amb"
+run_train "$CONFIG_DIR/app_a0all.mtl3.json"    "EACL23_MTL3"
+run_train "$CONFIG_DIR/app_a0all.mtl6.json"    "EACL23_MTL6"
+
+predict_runs() {
+  local prefix="$1"
+  for seed in $SEEDS; do
+    local run_dir
+    run_dir=$(ls -d logs/**/"${prefix}_s${seed}" 2>/dev/null | tail -n 1 || true)
+    if [[ -z "$run_dir" ]]; then
+      echo "Missing run dir for ${prefix} seed ${seed}" >&2
+      continue
+    fi
+    echo "[PRED ] ${run_dir}"
+    python3 predict.py \
+      "$run_dir/model.pt" \
+      "$BASE/test.tsv" \
+      "$OUT/${prefix}_s${seed}.pred.txt" \
+      --dataset MD \
+      --device 0
+  done
+}
+
+predict_runs "EACL23_App"
+predict_runs "EACL23_AppA0all"
+predict_runs "EACL23_AppA0subj"
+predict_runs "EACL23_AppA0miss"
+predict_runs "EACL23_AppA0amb"
+predict_runs "EACL23_MTL3"
+predict_runs "EACL23_MTL6"
+
+cd "$ROOT"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_App_s*.pred.txt" \
+  --group_by subtype \
+  --out_json "$OUT/table2_by_subtype.json"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_App_s*.pred.txt" \
+  --group_by category \
+  --out_json "$OUT/table2_by_category.json"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_App_s*.pred.txt" \
+  --group_by category \
+  --out_json "$OUT/table3_App.json"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_AppA0all_s*.pred.txt" \
+  --group_by category \
+  --out_json "$OUT/table3_App_A0all.json"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_AppA0subj_s*.pred.txt" \
+  --group_by category \
+  --out_json "$OUT/table3_App_A0_SUBJ.json"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_AppA0miss_s*.pred.txt" \
+  --group_by category \
+  --out_json "$OUT/table3_App_A0_MISS.json"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_AppA0amb_s*.pred.txt" \
+  --group_by category \
+  --out_json "$OUT/table3_App_A0_AMB.json"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_MTL3_s*.pred.txt" \
+  --group_by category \
+  --out_json "$OUT/table4_MTL3.json"
+
+python3 "$ROOT/score_groups.py" \
+  --test_tsv "$BASE/test.tsv" \
+  --pred_glob "$OUT/EACL23_MTL6_s*.pred.txt" \
+  --group_by category \
+  --out_json "$OUT/table4_MTL6.json"

--- a/eacl23_disagreement/score_groups.py
+++ b/eacl23_disagreement/score_groups.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Compute F1 scores overall and by group for MaChAmp predictions."""
+
+import argparse
+import glob
+import json
+from collections import defaultdict
+
+import numpy as np
+from sklearn.metrics import f1_score
+
+
+def read_split(tsv_path):
+    rows = []
+    with open(tsv_path, encoding="utf8") as handle:
+        for line in handle:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            rows.append(parts)
+    return rows
+
+
+def read_preds(pred_path):
+    with open(pred_path, encoding="utf8") as handle:
+        return [line.strip() for line in handle]
+
+
+def f1s(y_true, y_pred):
+    overall = f1_score(y_true, y_pred, average="micro", labels=["OFF", "NOT"])
+    off_f1 = f1_score(y_true, y_pred, pos_label="OFF")
+    not_f1 = f1_score(y_true, y_pred, pos_label="NOT")
+    return overall, off_f1, not_f1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Score MaChAmp prediction files.")
+    parser.add_argument("--test_tsv", required=True)
+    parser.add_argument(
+        "--pred_glob",
+        required=True,
+        help="Glob matching prediction files (one label per line)",
+    )
+    parser.add_argument(
+        "--group_by",
+        choices=["category", "subtype", "none"],
+        default="none",
+        help="Aggregate metrics per group",
+    )
+    parser.add_argument("--out_json", required=True)
+    args = parser.parse_args()
+
+    test_rows = read_split(args.test_tsv)
+    gold = [row[1] for row in test_rows]
+    categories = [row[4] if len(row) > 4 else "" for row in test_rows]
+    subtypes = [row[5] if len(row) > 5 else "" for row in test_rows]
+
+    groups = {"__ALL__": list(range(len(gold)))}
+    if args.group_by == "category":
+        groups = defaultdict(list)
+        for idx, category in enumerate(categories):
+            if category:
+                groups[category].append(idx)
+    elif args.group_by == "subtype":
+        groups = defaultdict(list)
+        for idx, subtype in enumerate(subtypes):
+            if subtype:
+                groups[subtype].append(idx)
+
+    runs = []
+    for pred_path in sorted(glob.glob(args.pred_glob)):
+        preds = read_preds(pred_path)
+        if len(preds) != len(gold):
+            raise ValueError(
+                f"Prediction length mismatch: {pred_path} has {len(preds)} items but gold has {len(gold)}"
+            )
+        per_group = {}
+        for group_name, indices in groups.items():
+            if not indices:
+                continue
+            gold_subset = [gold[i] for i in indices]
+            pred_subset = [preds[i] for i in indices]
+            overall, off_f1, not_f1 = f1s(gold_subset, pred_subset)
+            per_group[group_name] = {
+                "ALL": overall,
+                "OFF": off_f1,
+                "NOT": not_f1,
+            }
+        runs.append(per_group)
+
+    if not runs:
+        raise ValueError("No prediction files matched the provided glob.")
+
+    aggregated = {}
+    for group_name in runs[0]:
+        for metric in ["ALL", "OFF", "NOT"]:
+            values = [run[group_name][metric] for run in runs]
+            aggregated.setdefault(group_name, {})[metric] = {
+                "mean": float(np.mean(values)),
+                "std": float(np.std(values)),
+            }
+
+    with open(args.out_json, "w", encoding="utf8") as handle:
+        json.dump(aggregated, handle, indent=2)
+    print("Wrote", args.out_json)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add README and helper scripts to normalize MD-Agreement data, build training variants, generate MaChAmp configs, and score experiment outputs
- provide a run script that launches the single-task and multi-task experiments and aggregates the reported tables
- include the MaChAmp parameter override for bert-base-uncased and ignore Python bytecode artifacts

## Testing
- python3 -m compileall eacl23_disagreement

------
https://chatgpt.com/codex/tasks/task_e_68c85cdb8954832eb2515773731d8b45